### PR TITLE
ci: migrate to self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   sonarqube:
     name: SonarQube
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Migrate CI to self-hosted runner

Replaces GitHub-hosted `runs-on:` labels with the self-hosted runner fleet defined in [`shapeandshare/gh-runner-standalone`](https://github.com/shapeandshare/gh-runner-standalone):

- `ubuntu-latest` / `ubuntu-XX.XX` → `[self-hosted, linux, x64]` (AWS EC2 track)
- `macos-latest` / `macos-XX` → `[self-hosted, macOS, arm64, bare-metal]` (Apple Silicon bare-metal track)
- `windows-latest` left untouched (no self-hosted Windows runner exists yet)

All runners register at the org level under the `default` runner group, so no additional repo configuration is required.

_Automated migration PR._